### PR TITLE
Allow for new repository name

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -27,7 +27,7 @@ function activate(context) {
 		var currentFilePath = editor.document.uri.fsPath;
 		console.log('The current file = ' + currentFilePath);
 		if (editor.document.isUntitled) {
-			vscode.window.showInformationMessage("This doesn't work on files that aren't saved in the help-docs directory.");
+			vscode.window.showInformationMessage("This doesn't work on files that aren't saved in the GitHub docs repository.");
 			return;
 		}
 
@@ -59,7 +59,7 @@ function activate(context) {
 			var filepath = regexmatchArray[1];
 			filepath = filepath.replace(/\./g, directorySeparator);
 			
-			regex = new RegExp(".*\\" + directorySeparator + "help-docs\\" + directorySeparator, "g");
+			regex = new RegExp(".*\\" + directorySeparator + "(help-docs|docs-internal)\\" + directorySeparator, "g");
 			regexmatchArray = currentFilePath.match(regex);
 			var basepath = regexmatchArray[0] + "data" + directorySeparator;
 			console.log('basepath = ' + basepath);


### PR DESCRIPTION
👋  @hubwriter!

After the docs repo was renamed to `docs-internal`, I renamed my local repo to match it. I was horrified when I realised that this extension didn't work anymore 😆 

I've modified the regex to match both the old name (for the sane people who won't rename their local copy), as well as the new name.