### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -480,7 +480,7 @@
 				"js-yaml": "^3.13.1",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.3.0",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.19",
 				"minimatch": "^3.0.4",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
@@ -869,7 +869,7 @@
 				"cli-width": "^2.0.0",
 				"external-editor": "^3.0.3",
 				"figures": "^3.0.0",
-				"lodash": "^4.17.15",
+				"lodash": "^4.17.19",
 				"mute-stream": "0.0.8",
 				"run-async": "^2.4.0",
 				"rxjs": "^6.5.3",
@@ -1072,9 +1072,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"version": "4.17.19",
+			"resolved": "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
 			"dev": true
 		},
 		"log-symbols": {
@@ -1635,7 +1635,7 @@
 			"dev": true,
 			"requires": {
 				"ajv": "^6.10.2",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.19",
 				"slice-ansi": "^2.1.0",
 				"string-width": "^3.0.0"
 			},
@@ -1928,7 +1928,7 @@
 			"dev": true,
 			"requires": {
 				"flat": "^4.1.0",
-				"lodash": "^4.17.15",
+				"lodash": "^4.17.19",
 				"yargs": "^13.3.0"
 			}
 		}


### PR DESCRIPTION
Dependabot reported that versions <4.17.19 are unsafe.