### PR TITLE
Remove `help-docs`, use `docs` instead

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -59,7 +59,7 @@ function activate(context) {
 			var filepath = regexmatchArray[1];
 			filepath = filepath.replace(/\./g, directorySeparator);
 			
-			regex = new RegExp(".*\\" + directorySeparator + "(help-docs|docs-internal)\\" + directorySeparator, "g");
+			regex = new RegExp(".*\\" + directorySeparator + "(docs|docs-internal)\\" + directorySeparator, "g");
 			regexmatchArray = currentFilePath.match(regex);
 			var basepath = regexmatchArray[0] + "data" + directorySeparator;
 			console.log('basepath = ' + basepath);


### PR DESCRIPTION
This change lets the extension work with the default directory name of the open source [`docs`](https://github.com/github/docs) repository. It also removes the old `help-docs` directory name, as I wouldn't think too many people are using that repository anymore.